### PR TITLE
[feat] 통계 조회 API 구현

### DIFF
--- a/src/app/(withNavbar)/(withAuth)/myPage/page.tsx
+++ b/src/app/(withNavbar)/(withAuth)/myPage/page.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useState } from "react";
+import { useRouter } from "next/navigation";
 
 import FollowIcon from "@/assets/follow.svg";
 import FollowingIcon from "@/assets/following.svg";
@@ -20,7 +21,7 @@ export default function MyPage() {
   const myId = data?.result.userId ?? null;
 
   const [keyword, setKeyword] = useState("");
-
+  const router = useRouter();
   const { data: searchResults = [] } = useSearchUsers(keyword);
 
   const addFriend = useAddFriendMutation(myId ?? 0);
@@ -119,7 +120,11 @@ export default function MyPage() {
         </div>
 
         <div className="mt-8 mb-2 grid grid-cols-2 gap-4">
-          <ActionInnerButton icon={<StatisticsIcon className="size-8" />} label="통계 보러가기" />
+          <ActionInnerButton
+            icon={<StatisticsIcon className="size-8" />}
+            label="통계 보러가기"
+            onClick={() => router.push("/myPage/stats")}
+          />
           <ActionInnerButton icon={<NotebookIcon className="size-8" />} label="일기 작성하기" />
         </div>
       </div>

--- a/src/app/(withoutNavbar)/(withAuth)/myPage/stats/page.tsx
+++ b/src/app/(withoutNavbar)/(withAuth)/myPage/stats/page.tsx
@@ -67,7 +67,7 @@ export default function Stats() {
       </section>
       <section className="space-y-2">
         <p className="text-xl">일별 통계</p>
-        <DailyChart />
+        <DailyChart selectedMonth={selectedMonth} />
       </section>
     </main>
   );

--- a/src/app/(withoutNavbar)/(withAuth)/myPage/stats/page.tsx
+++ b/src/app/(withoutNavbar)/(withAuth)/myPage/stats/page.tsx
@@ -63,7 +63,7 @@ export default function Stats() {
       </section>
       <section className="space-y-2">
         <p className="text-xl">전체 통계</p>
-        <TotalChart />
+        <TotalChart selectedMonth={selectedMonth} />
       </section>
       <section className="space-y-2">
         <p className="text-xl">일별 통계</p>

--- a/src/components/myPage/stats/DailyChart.tsx
+++ b/src/components/myPage/stats/DailyChart.tsx
@@ -3,79 +3,173 @@
 import { useEffect, useRef } from "react";
 import Image from "next/image";
 
+import { useGetMonthlyEmotionStatus } from "@/lib/tanstack/query/emotion-status";
+import { cn } from "@/utils/cn";
+
 import {
   CategoryScale,
   Chart,
+  Legend,
   LinearScale,
   LineController,
   LineElement,
   PointElement,
+  Tooltip,
 } from "chart.js";
+import { format } from "date-fns";
 
-Chart.register([LineElement, LinearScale, LineController, CategoryScale, PointElement]);
+interface DailyChartProps {
+  selectedMonth: Date;
+}
 
-const chartData = {
-  labels: ["Day 1", "Day 2", "Day 3", "Day 4", "Day 5", "Day 6"],
-  datasets: [
-    {
-      label: "Dataset",
-      data: [1, 2, 3, 4, 5, 6],
-      borderColor: "rgb(255, 99, 132)",
-      backgroundColor: "rgba(255, 99, 132, 0.5)",
-      pointStyle: "circle",
-      pointRadius: 5,
-      pointHoverRadius: 10,
-    },
-  ],
-};
+Chart.register(
+  LineElement,
+  LinearScale,
+  LineController,
+  CategoryScale,
+  PointElement,
+  Tooltip,
+  Legend
+);
 
 const positiveDalbam = "/dalbam/thumbsUp.webp";
 const negativeDalbam = "/dalbam/crying.webp";
 
-export default function DailyChart() {
+const positiveColor = "rgb(54, 162, 235)";
+const positiveBackgroundColor = "rgba(54, 162, 235, 0.3)";
+const negativeColor = "rgb(255, 125, 82)";
+const negativeBackgroundColor = "rgba(255, 125, 82, 0.3)";
+
+export default function DailyChart({ selectedMonth }: DailyChartProps) {
+  const formattedMonth = format(selectedMonth, "yyyy-MM");
+
+  const { data: monthlyEmotionStatus } = useGetMonthlyEmotionStatus(formattedMonth);
+
   const chartRef = useRef<HTMLCanvasElement>(null);
+  const chartInstanceRef = useRef<Chart | null>(null);
 
   useEffect(() => {
-    if (!chartRef.current) return;
+    if (!chartRef.current || !monthlyEmotionStatus) return;
 
-    const chart = new Chart(chartRef.current, {
+    const labels = monthlyEmotionStatus.diaries.map((diary) => `${diary.date}일`);
+    const positiveData = monthlyEmotionStatus.diaries.map((diary) => diary.positiveCount);
+    const negativeData = monthlyEmotionStatus.diaries.map((diary) => diary.negativeCount);
+
+    // 기존 차트 제거
+    if (chartInstanceRef.current) {
+      chartInstanceRef.current.destroy();
+    }
+
+    chartInstanceRef.current = new Chart(chartRef.current, {
       type: "line",
-      data: chartData,
+      data: {
+        labels,
+        datasets: [
+          {
+            label: "긍정",
+            data: positiveData,
+            borderColor: positiveColor,
+            backgroundColor: positiveBackgroundColor,
+            yAxisID: "posY",
+            tension: 0.3,
+            pointRadius: 4,
+          },
+          {
+            label: "부정",
+            data: negativeData,
+            borderColor: negativeColor,
+            backgroundColor: negativeBackgroundColor,
+            yAxisID: "negY",
+            tension: 0.3,
+            pointRadius: 4,
+          },
+        ],
+      },
       options: {
         responsive: true,
+        interaction: {
+          mode: "index",
+          intersect: false,
+        },
+        scales: {
+          posY: {
+            type: "linear",
+            display: true,
+            position: "left",
+            title: {
+              display: true,
+              text: "긍정 감정",
+            },
+            beginAtZero: true,
+          },
+          negY: {
+            type: "linear",
+            display: true,
+            position: "right",
+            title: {
+              display: true,
+              text: "부정 감정",
+            },
+            beginAtZero: true,
+            grid: {
+              drawOnChartArea: false,
+            },
+          },
+        },
       },
     });
 
     return () => {
-      chart.destroy();
+      chartInstanceRef.current?.destroy();
     };
-  }, []);
+  }, [monthlyEmotionStatus]);
+
+  const totalDiaryCount = monthlyEmotionStatus.positiveCount + monthlyEmotionStatus.negativeCount;
+  const isPositiveMonth = monthlyEmotionStatus.positiveCount >= monthlyEmotionStatus.negativeCount;
 
   return (
-    <div className="space-y-4">
-      <canvas ref={chartRef} />
-      <div className="space-y-2">
+    <div className="space-y-6">
+      <div className="overflow-x-auto">
+        <div className="min-w-[500px] overflow-x-auto">
+          <canvas ref={chartRef} />
+        </div>
+      </div>
+
+      <div className="space-y-2 text-sm">
         <div className="flex items-center justify-between">
           <p>총 일기 수</p>
-          <p className="text-primary-100 text-sm">4개</p>
+          <p className="text-primary-100">{totalDiaryCount}일</p>
         </div>
         <div className="flex items-center justify-between">
           <p>긍정적인 날</p>
-          <p className="text-primary-100 text-sm">3일</p>
+          <p className="text-primary-100">{monthlyEmotionStatus.positiveCount}일</p>
         </div>
         <div className="flex items-center justify-between">
           <p>부정적인 날</p>
-          <p className="text-primary-100 text-sm">1일</p>
+          <p className="text-primary-100">{monthlyEmotionStatus.negativeCount}일</p>
         </div>
       </div>
-      {/* 부정적인 경우 flex-row-reverse 적용하기 */}
-      <div className="flex items-center justify-center gap-4">
-        <p>
+
+      <div
+        className={cn(
+          "flex items-center justify-center gap-4",
+          !isPositiveMonth && "flex-row-reverse"
+        )}
+      >
+        <p className="text-center">
           이번 달은
           <br />
-          <span className="text-xl">긍정적인 날</span>이 많아요.
+          <span className="text-xl font-semibold">
+            {isPositiveMonth ? "긍정적인 날" : "부정적인 날"}
+          </span>
+          이 많아요.
         </p>
-        <Image src={positiveDalbam} alt="positive dalbam" width={100} height={100} />
+        <Image
+          src={isPositiveMonth ? positiveDalbam : negativeDalbam}
+          alt="emotion dalbam"
+          width={100}
+          height={100}
+        />
       </div>
     </div>
   );

--- a/src/components/myPage/stats/DailyChart.tsx
+++ b/src/components/myPage/stats/DailyChart.tsx
@@ -150,27 +150,29 @@ export default function DailyChart({ selectedMonth }: DailyChartProps) {
         </div>
       </div>
 
-      <div
-        className={cn(
-          "flex items-center justify-center gap-4",
-          !isPositiveMonth && "flex-row-reverse"
-        )}
-      >
-        <p className="text-center">
-          이번 달은
-          <br />
-          <span className="text-xl font-semibold">
-            {isPositiveMonth ? "긍정적인 날" : "부정적인 날"}
-          </span>
-          이 많아요.
-        </p>
-        <Image
-          src={isPositiveMonth ? positiveDalbam : negativeDalbam}
-          alt="emotion dalbam"
-          width={100}
-          height={100}
-        />
-      </div>
+      {totalDiaryCount > 0 && (
+        <div
+          className={cn(
+            "flex items-center justify-center gap-4",
+            !isPositiveMonth && "flex-row-reverse"
+          )}
+        >
+          <p className="text-center">
+            이번 달은
+            <br />
+            <span className="text-xl font-semibold">
+              {isPositiveMonth ? "긍정적인 날" : "부정적인 날"}
+            </span>
+            이 많아요.
+          </p>
+          <Image
+            src={isPositiveMonth ? positiveDalbam : negativeDalbam}
+            alt="emotion dalbam"
+            width={100}
+            height={100}
+          />
+        </div>
+      )}
     </div>
   );
 }

--- a/src/components/myPage/stats/TotalChart.tsx
+++ b/src/components/myPage/stats/TotalChart.tsx
@@ -22,12 +22,13 @@ export default function TotalChart({ selectedMonth }: TotalChartProps) {
   const { data: emotionStatus } = useGetEmotionStatus(formattedMonth);
 
   const chartRef = useRef<HTMLCanvasElement>(null);
+  const chartInstanceRef = useRef<Chart | null>(null);
 
   const chartData = useMemo(() => {
     if (!emotionStatus) return null;
 
     return {
-      labels: ["긍정", "부정"],
+      labels: [`긍정 ${emotionStatus.positiveCount}`, `부정 ${emotionStatus.negativeCount}`],
       datasets: [
         {
           data: [emotionStatus.positiveCount, emotionStatus.negativeCount],
@@ -40,13 +41,17 @@ export default function TotalChart({ selectedMonth }: TotalChartProps) {
   useEffect(() => {
     if (!chartRef.current || !chartData) return;
 
-    const chart = new Chart(chartRef.current, {
+    if (chartInstanceRef.current) {
+      chartInstanceRef.current.destroy();
+    }
+
+    chartInstanceRef.current = new Chart(chartRef.current, {
       type: "pie",
       data: chartData,
     });
 
     return () => {
-      chart.destroy();
+      chartInstanceRef.current?.destroy();
     };
   }, [chartData]);
 
@@ -54,21 +59,5 @@ export default function TotalChart({ selectedMonth }: TotalChartProps) {
     return <p className="text-primary-100">해당 달에는 일기를 작성하지 않았어요.</p>;
   }
 
-  return (
-    <div className="space-y-2">
-      <canvas ref={chartRef} />
-      <div className="flex items-center justify-center gap-5">
-        <div className="flex items-center gap-1">
-          <div className="size-2 rounded-full" style={{ backgroundColor: positiveColor }} />
-          <p>긍정</p>
-          <p>{emotionStatus.positiveCount}</p>
-        </div>
-        <div className="flex items-center gap-1">
-          <div className="size-2 rounded-full" style={{ backgroundColor: negativeColor }} />
-          <p>부정</p>
-          <p>{emotionStatus.negativeCount}</p>
-        </div>
-      </div>
-    </div>
-  );
+  return <canvas ref={chartRef} />;
 }

--- a/src/components/myPage/stats/TotalChart.tsx
+++ b/src/components/myPage/stats/TotalChart.tsx
@@ -2,36 +2,43 @@
 
 import { useEffect, useMemo, useRef } from "react";
 
+import { useGetEmotionStatus } from "@/lib/tanstack/query/emotion-status";
+
 import { ArcElement, Chart, PieController } from "chart.js";
+import { format } from "date-fns";
+
+interface TotalChartProps {
+  selectedMonth: Date;
+}
 
 Chart.register([PieController, ArcElement]);
-
-const data = {
-  positiveCount: 2,
-  negativeCount: 1,
-};
 
 const positiveColor = "rgb(54, 162, 235)";
 const negativeColor = "rgb(255, 125, 82)";
 
-export default function TotalChart() {
+export default function TotalChart({ selectedMonth }: TotalChartProps) {
+  const formattedMonth = format(selectedMonth, "yyyy-MM");
+
+  const { data: emotionStatus } = useGetEmotionStatus(formattedMonth);
+
   const chartRef = useRef<HTMLCanvasElement>(null);
 
-  const chartData = useMemo(
-    () => ({
+  const chartData = useMemo(() => {
+    if (!emotionStatus) return null;
+
+    return {
       labels: ["긍정", "부정"],
       datasets: [
         {
-          data: [data.positiveCount, data.negativeCount],
+          data: [emotionStatus.positiveCount, emotionStatus.negativeCount],
           backgroundColor: [positiveColor, negativeColor],
         },
       ],
-    }),
-    []
-  );
+    };
+  }, [emotionStatus]);
 
   useEffect(() => {
-    if (!chartRef.current) return;
+    if (!chartRef.current || !chartData) return;
 
     const chart = new Chart(chartRef.current, {
       type: "pie",
@@ -43,6 +50,10 @@ export default function TotalChart() {
     };
   }, [chartData]);
 
+  if (!emotionStatus) {
+    return <p className="text-primary-100">해당 달에는 일기를 작성하지 않았어요.</p>;
+  }
+
   return (
     <div className="space-y-2">
       <canvas ref={chartRef} />
@@ -50,12 +61,12 @@ export default function TotalChart() {
         <div className="flex items-center gap-1">
           <div className="size-2 rounded-full" style={{ backgroundColor: positiveColor }} />
           <p>긍정</p>
-          <p>{data.positiveCount}</p>
+          <p>{emotionStatus.positiveCount}</p>
         </div>
         <div className="flex items-center gap-1">
           <div className="size-2 rounded-full" style={{ backgroundColor: negativeColor }} />
           <p>부정</p>
-          <p>{data.negativeCount}</p>
+          <p>{emotionStatus.negativeCount}</p>
         </div>
       </div>
     </div>

--- a/src/lib/tanstack/query/emotion-status.ts
+++ b/src/lib/tanstack/query/emotion-status.ts
@@ -1,10 +1,18 @@
-import { getEmotionStatus } from "@/services/emotion-status";
+import { getEmotionStatus, getMonthlyEmotionStatus } from "@/services/emotion-status";
 import { useSuspenseQuery } from "@tanstack/react-query";
 
 export const useGetEmotionStatus = (yearMonth: string) => {
   return useSuspenseQuery({
     queryKey: ["emotionStatus", yearMonth],
     queryFn: () => getEmotionStatus(yearMonth),
+    select: (data) => data.result,
+  });
+};
+
+export const useGetMonthlyEmotionStatus = (yearMonth: string) => {
+  return useSuspenseQuery({
+    queryKey: ["monthlyEmotionStatus", yearMonth],
+    queryFn: () => getMonthlyEmotionStatus(yearMonth),
     select: (data) => data.result,
   });
 };

--- a/src/lib/tanstack/query/emotion-status.ts
+++ b/src/lib/tanstack/query/emotion-status.ts
@@ -1,0 +1,10 @@
+import { getEmotionStatus } from "@/services/emotion-status";
+import { useSuspenseQuery } from "@tanstack/react-query";
+
+export const useGetEmotionStatus = (yearMonth: string) => {
+  return useSuspenseQuery({
+    queryKey: ["emotionStatus", yearMonth],
+    queryFn: () => getEmotionStatus(yearMonth),
+    select: (data) => data.result,
+  });
+};

--- a/src/models/emotion-status.ts
+++ b/src/models/emotion-status.ts
@@ -1,4 +1,10 @@
+import type { DiaryEmotionStatusProps } from "@/types/emotion-status";
+
 export interface EmotionStatusResponseDTO {
   positiveCount: number;
   negativeCount: number;
+}
+
+export interface MonthlyEmotionStatusResponseDTO extends EmotionStatusResponseDTO {
+  diaries: DiaryEmotionStatusProps[];
 }

--- a/src/models/emotion-status.ts
+++ b/src/models/emotion-status.ts
@@ -1,0 +1,4 @@
+export interface EmotionStatusResponseDTO {
+  positiveCount: number;
+  negativeCount: number;
+}

--- a/src/services/emotion-status.ts
+++ b/src/services/emotion-status.ts
@@ -1,0 +1,10 @@
+import api from "@/lib/axios";
+import type { BaseResponseDTO } from "@/models/base";
+import type { EmotionStatusResponseDTO } from "@/models/emotion-status";
+
+export const getEmotionStatus = async (
+  yearMonth: string
+): Promise<BaseResponseDTO<EmotionStatusResponseDTO>> => {
+  const { data } = await api.get(`/emotion-status?year-month=${yearMonth}`);
+  return data;
+};

--- a/src/services/emotion-status.ts
+++ b/src/services/emotion-status.ts
@@ -1,10 +1,20 @@
 import api from "@/lib/axios";
 import type { BaseResponseDTO } from "@/models/base";
-import type { EmotionStatusResponseDTO } from "@/models/emotion-status";
+import type {
+  EmotionStatusResponseDTO,
+  MonthlyEmotionStatusResponseDTO,
+} from "@/models/emotion-status";
 
 export const getEmotionStatus = async (
   yearMonth: string
 ): Promise<BaseResponseDTO<EmotionStatusResponseDTO>> => {
   const { data } = await api.get(`/emotion-status?year-month=${yearMonth}`);
+  return data;
+};
+
+export const getMonthlyEmotionStatus = async (
+  yearMonth: string
+): Promise<BaseResponseDTO<MonthlyEmotionStatusResponseDTO>> => {
+  const { data } = await api.get(`/emotion-status/date?year-month=${yearMonth}`);
   return data;
 };

--- a/src/types/emotion-status.ts
+++ b/src/types/emotion-status.ts
@@ -1,0 +1,5 @@
+export interface DiaryEmotionStatusProps {
+  date: string;
+  positiveCount: number;
+  negativeCount: number;
+}


### PR DESCRIPTION
## #️⃣연관된 이슈

> ex) #이슈번호, #이슈번호

#37 

## 📝작업 내용

> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)

통계 페이지에서 사용되는 API를 모두 연동했습니다.

### 스크린샷 (선택)

#### 작성한 일기가 있는 경우
<img width="1822" height="1186" alt="스크린샷 2025-12-16 오후 5 33 36" src="https://github.com/user-attachments/assets/56df51fe-d05d-4a85-b85f-d3dd1a11a4ae" />
<img width="1822" height="1186" alt="스크린샷 2025-12-16 오후 5 33 38" src="https://github.com/user-attachments/assets/a9ef7067-c994-4ad9-9090-11b8282930d5" />


#### 작성한 일기가 없는 경우
<img width="1822" height="1186" alt="스크린샷 2025-12-16 오후 5 34 19" src="https://github.com/user-attachments/assets/8758b800-6986-47f9-8c47-9096aa531897" />


## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
